### PR TITLE
Dropping php 7 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,11 +16,8 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: ["7.4", "8.0", "8.1"]
+                php: ["8.0", "8.1"]
                 symfony: ["^4.4", "^5.4", "6.0"]
-                exclude:
-                    - php: "7.4"
-                      symfony: "6.0"
 
         steps:
             -   uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ jobs:
             -   name: Restrict Symfony version
                 if: matrix.symfony != ''
                 run: |
+                    composer global config --no-plugins allow-plugins.symfony/flex true
                     composer global require --no-progress --no-scripts --no-plugins "symfony/flex:^1.11"
                     composer config extra.symfony.require "${{ matrix.symfony }}"
 


### PR DESCRIPTION
The idea is to start testing the currrent CI state.
Then I will work on adding php 8.3 and symfony 7 support when behat/behat will be ready.